### PR TITLE
Various Bugfixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { userSelect } from "./slices/userSlice";
 import { useDispatch } from "react-redux";
 import { lichessTrySetUser } from "./utils/lichess";
 import { UnknownAction } from "@reduxjs/toolkit";
+import { Toast } from "./components/common";
 
 const App = () => {
   const dispatch: Dispatch<UnknownAction> = useDispatch();
@@ -30,6 +31,7 @@ const App = () => {
 
   return (
     <>
+      <Toast />
       {!loading && <Outlet context={modelRefs} />}
     </>
   );

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -12,9 +12,10 @@ import VideoAndSidebar from "./videoAndSidebar";
 import StudyButton from "./studyButton";
 import FenButton from "./fenButton";
 import DeviceButton from "./deviceButton";
+import Toast from "./toast";
 
 export {
   SidebarButton, CornersButton, PgnButton, Icon, Corners,
   HomeButton, Sidebar, Container, VideoAndSidebar, RecordButton, StopButton, StudyButton,
-  FenButton, DeviceButton,
+  FenButton, DeviceButton, Toast,
 };

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -13,7 +13,7 @@ import StudyButton from "./studyButton";
 import FenButton from "./fenButton";
 import DeviceButton from "./deviceButton";
 
-export { 
+export {
   SidebarButton, CornersButton, PgnButton, Icon, Corners,
   HomeButton, Sidebar, Container, VideoAndSidebar, RecordButton, StopButton, StudyButton,
   FenButton, DeviceButton,

--- a/src/components/common/toast.tsx
+++ b/src/components/common/toast.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { Game, gameSelect, gameSetError } from "../../slices/gameSlice";
+
+const Toast = () => {
+  const game: Game = gameSelect();
+  const dispatch = useDispatch();
+  const [visible, setVisible] = useState(false);
+  const [show, setShow] = useState(false);
+
+  const dismiss = () => {
+    setVisible(false);
+    setTimeout(() => {
+      dispatch(gameSetError(null));
+      setShow(false);
+    }, 300);
+  };
+
+  useEffect(() => {
+    if (game.error) {
+      setShow(true);
+      setVisible(true);
+      const timer = setTimeout(dismiss, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [game.error]);
+
+  if (!show || !game.error) return null;
+
+  return (
+    <div
+      className="position-fixed top-0 end-0 m-3"
+      style={{ zIndex: 9999 }}
+    >
+      <div
+        className="toast show"
+        role="alert"
+        style={{
+          backgroundColor: "#dc3545",
+          color: "white",
+          opacity: visible ? 1 : 0,
+          transition: "opacity 0.3s ease-in-out",
+        }}
+      >
+        <div className="toast-body d-flex justify-content-between align-items-center">
+          {game.error}
+          <button
+            type="button"
+            className="btn-close btn-close-white"
+            onClick={dismiss}
+            style={{ filter: "invert(1)" }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/play/playSidebar.tsx
+++ b/src/components/play/playSidebar.tsx
@@ -31,7 +31,8 @@ const PlaySidebar = ({ piecesModelRef, xcornersModelRef, videoRef, canvasRef, si
   useEffect(() => {
     const colorToMove = gameRef.current.fen.split(" ")[1];
     const lastMove = gameRef.current.lastMove;
-    if ((colorToMove === color) || (lastMove === "") || (gameId === undefined) || (color === undefined)) {
+    const fromOpponent = gameRef.current.fromOpponent;
+    if ((colorToMove === color) || (lastMove === "") || (gameId === undefined) || (color === undefined) || fromOpponent) {
       return;
     }
 
@@ -51,8 +52,8 @@ const PlaySidebar = ({ piecesModelRef, xcornersModelRef, videoRef, canvasRef, si
     }
 
     const board = makeBoard(gameRef.current);
-    board.move(lastMove);
-    const payload = makeUpdatePayload(board);
+    board.playUci(lastMove);
+    const payload = makeUpdatePayload(board, false, true);
     console.log("payload", payload);
     dispatch(gameUpdate(payload));
   }

--- a/src/components/play/playSidebar.tsx
+++ b/src/components/play/playSidebar.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { lichessPlayMove, lichessStreamGame } from "../../utils/lichess";
 import { Color } from "chessops/types";
 import { useDispatch } from "react-redux";
-import { gameSelect, gameUpdate, makeBoard, makeUpdatePayload } from "../../slices/gameSlice";
+import { gameSelect, gameUpdate, gameSetError, makeBoard, makeUpdatePayload } from "../../slices/gameSlice";
 import GamesButton from "./gamesButton";
 
 const PlaySidebar = ({ piecesModelRef, xcornersModelRef, videoRef, canvasRef, sidebarRef,
@@ -36,7 +36,10 @@ const PlaySidebar = ({ piecesModelRef, xcornersModelRef, videoRef, canvasRef, si
       return;
     }
 
-    lichessPlayMove(token, gameId, lastMove);
+    lichessPlayMove(token, gameId, lastMove)
+      .catch((err: string) => {
+        dispatch(gameSetError(err));
+      });
   }, [gameRef.current])
 
   const streamGameCallback = async (response: any) => {

--- a/src/slices/gameSlice.tsx
+++ b/src/slices/gameSlice.tsx
@@ -5,15 +5,16 @@ import { START_FEN } from '../utils/constants';
 import { parseFen, makeFen } from 'chessops/fen';
 import { Chess } from 'chessops/chess';
 import { parsePgn } from 'chessops/pgn';
-import { parseSan } from 'chessops/san';
-import { makeUci } from 'chessops/util';
+import { parseSan, makeSan } from 'chessops/san';
+import { makeUci, parseUci } from 'chessops/util';
 
 const initialState: Game = {
   "moves": "",
   "fen": START_FEN,
   "start": START_FEN,
   "lastMove": "",
-  "greedy": false
+  "greedy": false,
+  "fromOpponent": false
 };
 
 const gameSlice = createSlice({
@@ -50,7 +51,8 @@ const gameSlice = createSlice({
         "moves": action.payload.moves,
         "fen": action.payload.fen,
         "lastMove": action.payload.lastMove,
-        "greedy": action.payload.greedy
+        "greedy": action.payload.greedy,
+        "fromOpponent": action.payload.fromOpponent
       }
       return newState
     }
@@ -82,7 +84,7 @@ export const makePgn = (game: Game) => {
   return `[FEN "${game.start}"]` + "\n \n" + game.moves;
 }
 
-export const makeUpdatePayload = (board: any, greedy: boolean = false) => {
+export const makeUpdatePayload = (board: any, greedy: boolean = false, fromOpponent: boolean = false) => {
   const history = board.history || [];
   const startFen = board.startFen || START_FEN;
 
@@ -94,7 +96,8 @@ export const makeUpdatePayload = (board: any, greedy: boolean = false) => {
     "moves": moves,
     "fen": fen,
     "lastMove": lastMove,
-    "greedy": greedy
+    "greedy": greedy,
+    "fromOpponent": fromOpponent
   }
 
   return payload
@@ -122,6 +125,18 @@ export const makeBoard = (game: Game): any => {
   board.playSan = (san: string) => {
     const move = parseSan(board, san);
     if (move) {
+      (move as any).san = san;
+      board.history.push(move);
+      board.play(move);
+      return move;
+    }
+    return null;
+  };
+
+  board.playUci = (uci: string) => {
+    const move = parseUci(uci);
+    if (move) {
+      const san = makeSan(board, move);
       (move as any).san = san;
       board.history.push(move);
       board.play(move);

--- a/src/slices/gameSlice.tsx
+++ b/src/slices/gameSlice.tsx
@@ -6,7 +6,9 @@ import { parseFen, makeFen } from 'chessops/fen';
 import { Chess } from 'chessops/chess';
 import { parsePgn } from 'chessops/pgn';
 import { parseSan, makeSan } from 'chessops/san';
-import { makeUci, parseUci } from 'chessops/util';
+import { makeUci, parseUci, Uci } from 'chessops/util';
+
+type HistoryEntry = { move: Uci; san: string };
 
 const initialState: Game = {
   "moves": "",
@@ -14,7 +16,8 @@ const initialState: Game = {
   "start": START_FEN,
   "lastMove": "",
   "greedy": false,
-  "fromOpponent": false
+  "fromOpponent": false,
+  "error": null
 };
 
 const gameSlice = createSlice({
@@ -45,6 +48,9 @@ const gameSlice = createSlice({
     gameResetLastMove(state) {
       state.lastMove = initialState.lastMove;
     },
+    gameSetError(state, action) {
+      state.error = action.payload;
+    },
     gameUpdate(state, action) {
       const newState: Game = {
         "start": state.start,
@@ -52,7 +58,8 @@ const gameSlice = createSlice({
         "fen": action.payload.fen,
         "lastMove": action.payload.lastMove,
         "greedy": action.payload.greedy,
-        "fromOpponent": action.payload.fromOpponent
+        "fromOpponent": action.payload.fromOpponent ?? false,
+        "error": action.payload.error ?? null
       }
       return newState
     }
@@ -60,18 +67,17 @@ const gameSlice = createSlice({
 })
 
 const getMovesFromPgn = (pos: any, startFen: string) => {
-  // Simple mainline PGN generator for chessops
   const setup = parseFen(startFen).unwrap();
   const tempPos = Chess.fromSetup(setup).unwrap();
-  const history = pos.history || []; // We'll need to attach history to our chessops board objects
+  const history = pos.history as HistoryEntry[] || [];
 
   let pgn = "";
-  history.forEach((move: any) => {
+  history.forEach((entry: HistoryEntry) => {
     if (tempPos.turn === 'white') {
       pgn += `${tempPos.fullmoves}. `;
     }
-    pgn += `${move.san} `;
-    tempPos.play(move);
+    pgn += `${entry.san} `;
+    tempPos.play(entry.move);
   });
   return pgn.trim();
 }
@@ -84,20 +90,21 @@ export const makePgn = (game: Game) => {
   return `[FEN "${game.start}"]` + "\n \n" + game.moves;
 }
 
-export const makeUpdatePayload = (board: any, greedy: boolean = false, fromOpponent: boolean = false) => {
-  const history = board.history || [];
+export const makeUpdatePayload = (board: any, greedy: boolean = false, fromOpponent: boolean = false, error: string | null = null) => {
+  const history = board.history as HistoryEntry[] || [];
   const startFen = board.startFen || START_FEN;
 
   const moves = getMovesFromPgn(board, startFen);
   const fen = makeFen(board.toSetup());
-  const lastMove = (history.length === 0) ? "" : makeUci(history[history.length - 1]);
+  const lastMove = (history.length === 0) ? "" : makeUci(history[history.length - 1].move);
 
   const payload = {
     "moves": moves,
     "fen": fen,
     "lastMove": lastMove,
     "greedy": greedy,
-    "fromOpponent": fromOpponent
+    "fromOpponent": fromOpponent,
+    "error": error
   }
 
   return payload
@@ -107,7 +114,7 @@ export const makeBoard = (game: Game): any => {
   const setup = parseFen(game.start).unwrap();
   const board: any = Chess.fromSetup(setup).unwrap();
   board.startFen = game.start;
-  board.history = [];
+  board.history = [] as HistoryEntry[];
 
   const updateFromHistory = () => {
     const freshSetup = parseFen(board.startFen).unwrap();
@@ -119,14 +126,14 @@ export const makeBoard = (game: Game): any => {
     board.halfmoves = freshBoard.halfmoves;
     board.fullmoves = freshBoard.fullmoves;
 
-    board.history.forEach((m: any) => board.play(m));
+    board.history.forEach((entry: HistoryEntry) => board.play(entry.move));
   };
 
   board.playSan = (san: string) => {
     const move = parseSan(board, san);
     if (move) {
-      (move as any).san = san;
-      board.history.push(move);
+      const entry: HistoryEntry = { move: move as Uci, san };
+      board.history.push(entry);
       board.play(move);
       return move;
     }
@@ -137,8 +144,8 @@ export const makeBoard = (game: Game): any => {
     const move = parseUci(uci);
     if (move) {
       const san = makeSan(board, move);
-      (move as any).san = san;
-      board.history.push(move);
+      const entry: HistoryEntry = { move, san };
+      board.history.push(entry);
       board.play(move);
       return move;
     }
@@ -165,6 +172,7 @@ export const {
   gameSetMoves, gameResetMoves,
   gameSetFen, gameResetFen,
   gameSetStart, gameResetStart,
-  gameSetLastMove, gameResetLastMove, gameUpdate
+  gameSetLastMove, gameResetLastMove,
+  gameUpdate, gameSetError
 } = gameSlice.actions
 export default gameSlice.reducer

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -32,7 +32,8 @@ interface Game {
   moves: string,
   start: string,
   lastMove: string,
-  greedy: boolean
+  greedy: boolean,
+  fromOpponent: boolean
 }
 
 interface User {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -33,7 +33,8 @@ interface Game {
   start: string,
   lastMove: string,
   greedy: boolean,
-  fromOpponent: boolean
+  fromOpponent: boolean,
+  error: string | null
 }
 
 interface User {

--- a/src/utils/findPieces.tsx
+++ b/src/utils/findPieces.tsx
@@ -220,7 +220,6 @@ export const findPieces = (modelRef: any, videoRef: any, canvasRef: any,
           boardRef.current.playSan(move);
           possibleMoves.clear();
           greedyMoveToTime = {};
-          state = zeros(64, 12);
         }
       }
 
@@ -237,7 +236,6 @@ export const findPieces = (modelRef: any, videoRef: any, canvasRef: any,
         if (hasGreedyMove) {
           boardRef.current.playSan(move);
           greedyMoveToTime = { greedyMove: greedyMoveToTime[move] };
-          state = zeros(64, 12);
         }
       }
 

--- a/src/utils/findPieces.tsx
+++ b/src/utils/findPieces.tsx
@@ -129,7 +129,7 @@ export const getUpdate = (scoresTensor: tf.Tensor2D, squares: number[]) => {
 
   for (let i = 0; i < squares.length; i++) {
     const square = squares[i];
-    if (square == -1) {
+    if (typeof square !== 'number' || !Number.isInteger(square) || square < 0 || square >= 64) {
       continue;
     }
     for (let j = 0; j < 12; j++) {
@@ -220,6 +220,7 @@ export const findPieces = (modelRef: any, videoRef: any, canvasRef: any,
           boardRef.current.playSan(move);
           possibleMoves.clear();
           greedyMoveToTime = {};
+          state = zeros(64, 12);
         }
       }
 
@@ -236,6 +237,7 @@ export const findPieces = (modelRef: any, videoRef: any, canvasRef: any,
         if (hasGreedyMove) {
           boardRef.current.playSan(move);
           greedyMoveToTime = { greedyMove: greedyMoveToTime[move] };
+          state = zeros(64, 12);
         }
       }
 

--- a/src/utils/lichess.tsx
+++ b/src/utils/lichess.tsx
@@ -65,7 +65,7 @@ const fetchResponse = async (token: string, path: string, options: any = {}) => 
   const res: any = await window.fetch(`${lichessHost}${path}`, config);
   if (!res.ok) {
     const err = `${res.status} ${res.statusText}`;
-    alert(err);
+    console.error(err);
     throw err;
   }
   return res;

--- a/src/utils/lichess.tsx
+++ b/src/utils/lichess.tsx
@@ -170,7 +170,7 @@ export const lichessPlayMove = (token: string, gameId: string, move: string) => 
   const options = {
     method: "POST"
   }
-  fetchResponse(token, path, options);
+  return fetchResponse(token, path, options);
 }
 
 export const lichessTrySetUser = async (navigate: NavigateFunction, dispatch: Dispatch<UnknownAction>) => {

--- a/src/utils/math.tsx
+++ b/src/utils/math.tsx
@@ -4,5 +4,5 @@ export const clamp = (x: number, min: number, max: number) => {
 }
 
 export const zeros = (rows: number, columns: number) => {
-  return Array.from(Array(rows), _ => Array(columns).fill(0));
+  return Array.from({ length: rows }, () => Array(columns).fill(0));
 }


### PR DESCRIPTION
Please note - this commit was AI-generated and I am not a very competent TS dev, please review before accepting.  Summary of changes:

1. `src/utils/findPieces.tsx` - Fixed `getUpdate` function (line 132)
  - Changed `if (square == -1)` to `if (typeof square !== 'number' || !Number.isInteger(square) || square < 0 || square >= 64)`
  - Fixes: `TypeError: can't access property 0, update[square] is undefined` - handles undefined/NaN/out-of-bounds square values from tensor operations

2. `src/utils/findPieces.tsx` - Reset state after move detection (lines 223, 240)
  - Added `state = zeros(64, 12);` after both move detection paths
  - Fixes: Second move being ignored - state now resets after each detected move

3. `src/utils/math.tsx` - Fixed zeros function
  - Changed `Array.from(Array(rows), ...)` to `Array.from({ length: rows }, ...)`
  - Fixes: Sparse array issues that could cause undefined rows

4. `src/components/play/playSidebar.tsx` - Fixed opponent move handling
  - Changed `board.move(lastMove)` to `board.playUci(lastMove)`
  - Added `fromOpponent` check to prevent sending opponent moves back to Lichess
  - Fixes: TypeError: board.move is not a function and duplicate move submissions

5. `src/slices/gameSlice.tsx` - Added playUci method
  - Added `parseUci` import and `makeSan` for converting UCI moves to SAN notation
  - Fixes: Opponent moves from Lichess stream not being properly added to game state

6. `src/types.tsx` & `src/slices/gameSlice.tsx` - Added `fromOpponent` field
  - Tracks whether a move came from the opponent (via stream) vs detected by camera
  - Fixes: System sending opponent's moves back to Lichess

7. `src/utils/lichess.tsx` - Removed alert popup
  - Changed `alert(err)` to `console.error(err)`
  - Fixes: Intrusive error alerts during Lichess API failures
